### PR TITLE
chore: update version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlize-query",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Converts sequelize queries from query params to sequelize query object ",
   "main": "sqlize.js",
   "scripts": {


### PR DESCRIPTION
numbers get converted to an object. this updates sets the value as long as the value isn't an object